### PR TITLE
Fixes #66

### DIFF
--- a/src/common.scss
+++ b/src/common.scss
@@ -1,15 +1,13 @@
 @mixin breakpoint($point) {
     @if $point == mobile {
-        @media (max-device-width: 899px)
-        , (max-device-width: 1024px) and (orientation: landscape)
-        , (min-resolution: 300dpi)
+        @media only screen and (min-device-width: 320px)
+        and (max-device-width: 480px)
         , (handheld) {
                 @content;
         }
     } @else if $point == mobile_or_small_width {
-        @media (max-device-width: 899px)
-        , (max-device-width: 1024px) and (orientation: landscape)
-        , (min-resolution: 300dpi)
+        @media only screen and (min-device-width: 320px)
+        and (max-device-width : 480px)
         , (handheld)
         , (max-width: 810px) {
                 @content;


### PR DESCRIPTION
Exclude low resolution desktops from media queries

I looked into this one quite deeply because something doesn't seem right here, the pull request that I've made is essentially a small patch to keep going forward with the approach we've taken up until now but I believe it may be flawed based on what I've looked at today

So the new breakpoint is taken from here: https://responsivedesign.is/develop/browser-feature-support/media-queries-for-common-device-breakpoints 

as you can see from the link there are various break points for different devices, I've only included the smartphone one and in emulation it seems to match every smart phone I've tested including larger iphones but does not include tablet devices, so with this pull request smartphones will match on mobile but not tablets (generally speaking)

Linked on that same page is this advice: 
https://responsivedesign.is/articles/why-you-dont-need-device-specific-breakpoints
which essentially advocates make your layout mobile first, extend your widths out until your content looks broken then add the breakpoints naturally around your content, that makes sense but the issue we've been contending with is everything looks tiny in mobile 

I believe it's because kitnic is missing a viewport meta tag: https://developers.google.com/web/fundamentals/design-and-ui/responsive/fundamentals/set-the-viewport?hl=en, purely for the fact that this looks very familiar: 

![image](https://cloud.githubusercontent.com/assets/198857/15360466/99528048-1d05-11e6-9f46-1d86f4975dff.png)

I tested this with Kitnic and it looks quite bad, I suspect because we've monkey patched some more css rules in for mobile to mitigate the tiny text in the first place 

For now I've addressed the issue at hand but we may need to re-think mobile detection as a concept later down the line

#66 
