### PR TITLE
add Logitech G25/G27 shifter/pedals adapter to use as standalone device

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -9,3 +9,4 @@ https://github.com/kitnic/BQ25570_Harvester
 https://github.com/JarrettR/USBvil
 https://github.com/8BitMixtape/NextLevelEdition
 https://github.com/dvdfreitag/Signal-Detector
+https://github.com/robotsrulz/SP_Adapter


### PR DESCRIPTION
Please add info about open source/open hardware Logitech G25/G27 shifter/pedals adapter.