### PR TITLE
Add dynamixel shield in board list

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -15,3 +15,4 @@ https://github.com/pcbsz/AtariSynth
 https://git.defproc.co.uk/DefProc/piezo-sensor
 https://github.com/pcbsz/LM386
 https://github.com/kanflo/aaduino
+https://github.com/descampsa/DynamixelShield


### PR DESCRIPTION
Hey, trying to add my little arduino shield.

All components appear to be found at mouser and digikey, but i was not able to add them to my cart with your chrome extension, so let me know if i did something wrong (1-clik_bom was generated manually from my mouser bom).