### PR TITLE
Added Neocococat

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -23,3 +23,4 @@ https://github.com/UDXS/Arduitsy
 https://github.com/monostable/jelly
 https://github.com/GenericLab/Gar-Lampli
 https://github.com/GenericLab/Unagi_Gar-Lampli
+https://github.com/kimitobo/Neocococat


### PR DESCRIPTION
Neocococat is a 8bitmixtape board modification made in Taipei following Marc Dusseillers DIY PCB workshop.